### PR TITLE
drop specific tqdm requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 torch==1.1.0
 pytorch-pretrained-bert==0.6.2
-tqdm==4.19.5
+tqdm
 pytools==2018.5.2
 git+https://github.com/cvangysel/pytrec_eval.git


### PR DESCRIPTION
colab needed me not to peg tqdm. 

Also, colab is upto torch 1.5 now, and has to be downgraded for cedr. But it appears to work fine in doing so.